### PR TITLE
inverted the D7 diode...

### DIFF
--- a/ATMEGA328P.sch
+++ b/ATMEGA328P.sch
@@ -286,7 +286,7 @@ F 10 "N" H 5300 1200 60  0001 C CNN "Critical"
 F 11 "328P_Sub" H 5300 1200 60  0001 C CNN "Subsystem"
 F 12 "~" H 5300 1200 60  0001 C CNN "Notes"
 	1    5300 1200
-	0    -1   -1   0   
+	0    1    1    0   
 $EndComp
 Wire Wire Line
 	4900 650  4900 1050


### PR DESCRIPTION
which was in the wrong direction. This  [image](https://rheingoldheavy.com/wp-content/uploads/2015/10/bare_bones_arduino_reset_circuit.png) is showing it in the right direction but  unfortunately in the git repo it was inserted the wrong way.

And Thanks to the great talk last year about this topic.
